### PR TITLE
Implemented memory peek/poke and CLI memory view

### DIFF
--- a/NeighborSharp/MemoryHelper.cs
+++ b/NeighborSharp/MemoryHelper.cs
@@ -1,0 +1,94 @@
+﻿using System.Runtime.InteropServices;
+
+namespace NeighborSharp
+{
+    public class MemoryHelper
+    {
+        public static void PrintBytes(byte[] data, uint baseAddr = 0)
+        {
+            var oldColour = Console.ForegroundColor;
+
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write("Address  ");
+
+            // Print top row.
+            for (int i = 0; i < 16; i++)
+                Console.Write($"{(i + baseAddr % 16):X2} ");
+
+            Console.WriteLine("");
+            Console.ForegroundColor = oldColour;
+
+            for (int i = 0; i < data.Length; i += 16)
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($"{(baseAddr + i):X8} ");
+                Console.ForegroundColor = oldColour;
+
+                for (int j = 0; j < 16; j++)
+                {
+                    int index = i + j;
+
+                    if (index < data.Length)
+                    {
+                        Console.Write($"{data[index]:X2} ");
+                    }
+                    else
+                    {
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.Write("?? ");
+                        Console.ForegroundColor = oldColour;
+                    }
+                }
+
+                Console.WriteLine();
+            }
+        }
+
+        public static T ByteArrayToStructure<T>(byte[] data) where T : struct
+        {
+            if (data == null || data.Length <= 0)
+                return default;
+
+            var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+
+            try
+            {
+                return (T)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(T));
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        public static byte[] StructureToByteArray<T>(T structure) where T : struct
+        {
+            byte[] data = new byte[Marshal.SizeOf(typeof(T))];
+
+            var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+
+            try
+            {
+                Marshal.StructureToPtr(structure, handle.AddrOfPinnedObject(), false);
+            }
+            finally
+            {
+                handle.Free();
+            }
+
+            return data;
+        }
+
+        public static byte[] HexStringToByteArray(string hexStr)
+        {
+            hexStr = hexStr.Replace("0x", "")
+                           .Replace(" ", "")
+                           .Replace("?", "");
+
+            return Enumerable.Range(0, hexStr.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hexStr.Substring(x, 2), 16))
+                             .ToArray();
+        }
+    }
+}

--- a/NeighborSharp/Xbox360.cs
+++ b/NeighborSharp/Xbox360.cs
@@ -6,8 +6,6 @@ namespace NeighborSharp
 {
     public class Xbox360
     {
-        private const int _maxReadableBytes = 64;
-
         public IPEndPoint EndPoint { get; }
         public string? DebugName { get; private set; }
 
@@ -41,23 +39,11 @@ namespace NeighborSharp
             return args.stringValues["name"];
         }
 
-        public byte[] ReadBytes(uint addr, int len = _maxReadableBytes)
+        public byte[] ReadBytes(uint addr, int len)
         {
             XBDMConnection conn = new(this);
-
-            var result = new List<byte>();
-            var chunks = (int)Math.Ceiling((double)len / _maxReadableBytes);
-
-            // XBDM only returns 64 bytes maximum, so we'll continue iterating in 64-byte chunks.
-            for (int i = 0; i < chunks; i++)
-            {
-                int chunkSize = Math.Min(_maxReadableBytes, len - result.Count);
-
-                var args = conn.CommandMultilineArg($"getmem addr={addr + i * _maxReadableBytes} length={chunkSize}");
-                result.AddRange(MemoryHelper.HexStringToByteArray(args.commands[0]));
-            }
-
-            return result.ToArray();
+            XboxArguments args = conn.CommandMultilineArg($"getmem addr={addr} length={len}");
+            return MemoryHelper.HexStringToByteArray(string.Join(string.Empty, args.commands));
         }
 
         public T Read<T>(uint addr) where T : unmanaged

--- a/NeighborTool/Program.cs
+++ b/NeighborTool/Program.cs
@@ -23,6 +23,8 @@ namespace NeighborTool
             Console.WriteLine("  listdisks - Lists all mounted drives available to the console.");
             Console.WriteLine("  listdir <directory> - Lists all files and subfolders in a directory on the console.");
             Console.WriteLine("  launch <remote file> [remote directory] - Launches an XEX on the console, optionally with a launch directory.");
+            Console.WriteLine("  mempeek <address> [length] - Peeks memory at the specified address.");
+            Console.WriteLine("  mempoke <address> [i8/i16/i32/i64/u8/u16/u32/u64/f32/f64] <data> - Pokes memory at the specified address with the input data.");
             Console.WriteLine("  download <remote file> <local file> - Downloads a file from the console.");
             Console.WriteLine("  upload <local file> <remote file> - Uploads a file to the console.");
             Console.WriteLine();
@@ -96,6 +98,69 @@ namespace NeighborTool
                     else
                         xbox.RunTitle(args[2]);
                     break;
+                case "mempeek":
+                    if (args.Length < 3)
+                    {
+                        PrintUsage(); return;
+                    }
+                    var peekAddr = Convert.ToUInt32(args[2], 16);
+                    var peekLen = args.Length == 4 ? Convert.ToInt32(args[3]) : 64;
+                    var peekResult = xbox.ReadBytes(peekAddr, peekLen);
+                    if (peekResult.Length <= 0)
+                        Console.WriteLine($"Failed to read data at 0x{peekAddr:X8}");
+                    else
+                        MemoryHelper.PrintBytes(peekResult, peekAddr);
+                    break;
+
+                case "mempoke":
+                {
+                    if (args.Length < 3)
+                    {
+                        PrintUsage();
+                        return;
+                    }
+
+                    var pokeAddr = Convert.ToUInt32(args[2], 16);
+                    var pokeLen = 0;
+                    XboxResponse pokeResponse = null;
+
+                    if (args.Length > 4)
+                    {
+                        switch (args[3])
+                        {
+                            case "i8":  pokeResponse = xbox.Write(pokeAddr, Convert.ToSByte(args[4]));  pokeLen = 1; break;
+                            case "u8":  pokeResponse = xbox.Write(pokeAddr, Convert.ToByte(args[4]));   pokeLen = 1; break;
+                            case "i16": pokeResponse = xbox.Write(pokeAddr, Convert.ToInt16(args[4]));  pokeLen = 2; break;
+                            case "u16": pokeResponse = xbox.Write(pokeAddr, Convert.ToUInt16(args[4])); pokeLen = 2; break;
+                            case "i32": pokeResponse = xbox.Write(pokeAddr, Convert.ToInt32(args[4]));  pokeLen = 4; break;
+                            case "u32": pokeResponse = xbox.Write(pokeAddr, Convert.ToUInt32(args[4])); pokeLen = 4; break;
+                            case "i64": pokeResponse = xbox.Write(pokeAddr, Convert.ToInt64(args[4]));  pokeLen = 8; break;
+                            case "u64": pokeResponse = xbox.Write(pokeAddr, Convert.ToUInt64(args[4])); pokeLen = 8; break;
+                            case "f32": pokeResponse = xbox.Write(pokeAddr, Convert.ToSingle(args[4])); pokeLen = 4; break;
+                            case "f64": pokeResponse = xbox.Write(pokeAddr, Convert.ToDouble(args[4])); pokeLen = 8; break;
+                        }
+                    }
+                    else
+                    {
+                        var pokeData = MemoryHelper.HexStringToByteArray(args[3]);
+
+                        pokeResponse = xbox.WriteBytes(pokeAddr, pokeData);
+                        pokeLen = pokeData.Length;
+                    }
+
+                    if (pokeResponse?.statusCode != 200)
+                    {
+                        Console.WriteLine($"Failed to write data to 0x{pokeAddr:X8}\nReason: {pokeResponse?.message}");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Successfully written data to 0x{pokeAddr:X8}\n");
+                        MemoryHelper.PrintBytes(xbox.ReadBytes(pokeAddr, pokeLen), pokeAddr);
+                    }
+
+                    break;
+                }
+
                 case "download":
                     if (args.Length < 4)
                     {


### PR DESCRIPTION
This PR adds four new functions to the `Xbox360` class for reading and writing memory.

- `byte[] ReadBytes(uint addr, int len)` - reads bytes from the input virtual address.
- `T Read<T>(uint addr)` - reads data from the input virtual address and implicitly casts it.
- `XboxResponse WriteBytes(uint addr, byte[] data)` - writes bytes to the input virtual address and returns the response.
- `XboxResponse Write<T>(uint addr, T data)` - writes data to the input virtual address and returns the response.

These are also used by the CLI program via new `mempeek` and `mempoke` commands.

![image](https://github.com/InvoxiPlayGames/NeighborSharp/assets/34012267/2c404d38-89ef-4ae6-a610-f5294044a9ea)